### PR TITLE
Remove invalid function parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Sometimes, you want to produce a `canvas` image instead of doing numeric computa
 For performance reasons, the return value for your function will no longer be anything useful. Instead, to display the image, retrieve the `canvas` DOM node and insert it into your page.
 
 ```js
-var render = gpu.createKernel(function(X) {
+var render = gpu.createKernel(function() {
     this.color(0, 0, 0, 1);
 }).dimensions([20, 20]).graphical(true);
     


### PR DESCRIPTION
Because of GPU.js's strict restrictions, the function passed to the kernel cannot have variable number of arguments passed to it.

Hence, either the `render` function should be called with a value or the function passed to the `createKernel` method should not accept any arguments. Because the function does not require any arguments, it's signature should not require any arguments as well.