### PR TITLE
Fix Android Dragons Truncation Bug

### DIFF
--- a/src/backend/mode_gpu.js
+++ b/src/backend/mode_gpu.js
@@ -325,6 +325,7 @@
 					'	rgba.b = integerMod(rgba.b, 128.0);',
 					'	rgba.a = exponent*0.5 + 63.5;',
 					'	rgba.ba += vec2(integerMod(exponent+127.0, 2.0), sign) * 128.0;',
+					'	rgba = floor(rgba);',
 					'	rgba *= 0.003921569; // 1/255',
 					(endianness == 'LE' ? '' : '	rgba.rgba = rgba.abgr;'),
 					'	return rgba;',

--- a/test/html/android_encode32_test.html
+++ b/test/html/android_encode32_test.html
@@ -1,0 +1,23 @@
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>GPU.JS : Android test</title>
+</head>
+<body>
+<script src="../../src/parser.js"></script>
+<script src="../../src/backend/GPUCore.js"></script>
+<script src="../../src/gpu.js"></script>
+<script src="../../src/utils.js"></script>
+<script src="../../src/texture.js"></script>
+<script src="../../src/backend/functionNode_webgl.js"></script>
+<script src="../../src/backend/functionNode.js"></script>
+<script src="../../src/backend/functionBuilder.js"></script>
+<script src="../../src/backend/mode_gpu.js"></script>
+<script src="../../src/backend/mode_cpu.js"></script>
+<script>
+document.write(new GPU().createKernel(function(){
+    return -this.thread.x / 5
+}).dimensions([15, 1])()[0].join('<br/>'));
+</script>
+</body>
+</html>


### PR DESCRIPTION
I borrowed the float encoding/decoding code for my own project, but found a bug when testing on my Android's Chrome (Note 3 running Lollipop). Apparently it rounds rather than truncates when converting the RGBA vec4 to 4 unsigned ints. Running android_encode32_test.html on my phone gives:

```
0
-0.20000000298023224
-0.4000000059604645
-0.5999999642372131
-0.800000011920929
-4
-4.799999713897705
-5.599999904632568
-6.400000095367432
-7.199999809265137
-2
-2.1999998092651367
-2.3999998569488525
-2.5999999046325684
-2.799999952316284
```

when it should be more like (as it is on my laptop):

```
0
-0.20000000298023224
-0.4000000059604645
-0.6000000238418579
-0.800000011920929
-1
-1.2000000476837158
-1.399999976158142
-1.600000023841858
-1.8000000715255737
-2
-2.200000047683716
-2.4000000953674316
-2.6000001430511475
-2.799999952316284
```

This is fixed by flooring the vec4 before returning.