### PR TITLE
Added missing gulp-rename dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
   },
   "dependencies": {},
   "devDependencies": {
-      "babel-plugin-syntax-async-functions": "^6.5.0",
-      "gulp": "^3.9.1",
-      "gulp-concat": "^2.6.0",
-      "gulp-header": "^1.7.1",
-      "gulp-uglify": "^1.5.2",
-      "gulp-util": "^3.0.7"
+    "babel-plugin-syntax-async-functions": "^6.5.0",
+    "gulp": "^3.9.1",
+    "gulp-concat": "^2.6.0",
+    "gulp-header": "^1.7.1",
+    "gulp-rename": "^1.2.2",
+    "gulp-uglify": "^1.5.2",
+    "gulp-util": "^3.0.7"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
gulp-rename was missing when I cloned the repo and tried to run locally.