### PR TITLE
fix(isWebgl): return a boolean

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -355,7 +355,7 @@ var GPUUtils = (function() {
 	function isWebgl( webglObj ) {
 		return (
 			webglObj != null &&
-			webglObj.getExtension
+			!!webglObj.getExtension
 		);
 	}
 	GPUUtils.isWebgl = isWebgl;

--- a/src/utils.js
+++ b/src/utils.js
@@ -355,7 +355,7 @@ var GPUUtils = (function() {
 	function isWebgl( webglObj ) {
 		return (
 			webglObj != null &&
-			!!webglObj.getExtension
+			webglObj.hasOwnProperty('getExtension')
 		);
 	}
 	GPUUtils.isWebgl = isWebgl;


### PR DESCRIPTION
This is to make `gpu.supportWebgl()` return a boolean instead of a function.

![gpu](https://cloud.githubusercontent.com/assets/2781777/21471928/89817c8c-caa2-11e6-93a8-e38aa90d577a.gif)
