### PR TITLE
Fixes npm modules to allow imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gpu.js",
   "version": "0.0.0",
   "description": "GPU Accelerated JavaScript",
-  "main": "",
+  "main": "./src/index.js",
   "directories": {
     "doc": "doc",
     "test": "test"


### PR DESCRIPTION
An empty string value for the "main" key in package.json prohibited imports(require) of the module. This PR fixes it.