### PR TITLE
Removes redundant check in runner-base

### DIFF
--- a/src/backend/runner-base.js
+++ b/src/backend/runner-base.js
@@ -59,10 +59,6 @@ module.exports = class BaseRunner {
 	buildKernel(fn, settings) {
 		settings = Object.assign({}, settings || {});
 		const fnString = fn.toString();
-		if (!utils.isFunctionString(fnString)) {
-			throw 'Unable to get body of kernel function';
-		}
-
 		if (!settings.functionBuilder) {
 			settings.functionBuilder = this.functionBuilder;
 		}


### PR DESCRIPTION
As discussed.

Brief: The function check is being done inside `createKernel` method of class `GPU` ( [Function check inside gpu.js-line-78](https://github.com/gpujs/gpu.js/blob/develop/src/gpu.js#L78) ) and hence this check is redundant.