### PR TITLE
Fix return of >=2d arrays from GPU

### DIFF
--- a/bin/gpu-browser-core.js
+++ b/bin/gpu-browser-core.js
@@ -5,7 +5,7 @@
  * GPU Accelerated JavaScript
  *
  * @version 2.0.0-rc.12
- * @date Fri Apr 26 2019 22:06:12 GMT-0400 (Eastern Daylight Time)
+ * @date Sun Apr 28 2019 15:00:27 GMT+0200 (CEST)
  *
  * @license MIT
  * The MIT License
@@ -3450,9 +3450,10 @@ class GLKernel extends Kernel {
 		const XResultsMax = xMax * 4;
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * XResultsMax;
 			let i = 0;
 			for (let x = 0; x < XResultsMax; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 2);
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 2);
 			}
 			yResults[y] = xResults;
 		}
@@ -3467,9 +3468,10 @@ class GLKernel extends Kernel {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
 				for (let x = 0; x < xResultsMax; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 2);
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 2);
 				}
 				yResults[y] = xResults;
 			}
@@ -3491,13 +3493,14 @@ class GLKernel extends Kernel {
 	render2DArray3() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax] = this.output;
-		const xMaxResults = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const yResults = new Array(yMax);
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * xResultsMax;
 			let i = 0;
-			for (let x = 0; x < xMaxResults; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 3);
+			for (let x = 0; x < xResultsMax; x += 4) {
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 3);
 			}
 			yResults[y] = xResults;
 		}
@@ -3506,15 +3509,16 @@ class GLKernel extends Kernel {
 	render3DArray3() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax, zMax] = this.output;
-		const xMaxResults = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const zResults = new Array(zMax);
 		for (let z = 0; z < zMax; z++) {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
-				for (let x = 0; x < xMaxResults; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 3);
+				for (let x = 0; x < xResultsMax; x += 4) {
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 3);
 				}
 				yResults[y] = xResults;
 			}
@@ -3536,13 +3540,14 @@ class GLKernel extends Kernel {
 	render2DArray4() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax] = this.output;
-		const xMaxResult = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const yResults = new Array(yMax);
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * xResultsMax;
 			let i = 0;
-			for (let x = 0; x < xMaxResult; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 4);
+			for (let x = 0; x < xResultsMax; x += 4) {
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 4);
 			}
 			yResults[y] = xResults;
 		}
@@ -3551,15 +3556,16 @@ class GLKernel extends Kernel {
 	render3DArray4() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax, zMax] = this.output;
-		const xResultsMap = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const zResults = new Array(zMax);
 		for (let z = 0; z < zMax; z++) {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
-				for (let x = 0; x < xResultsMap; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 4);
+				for (let x = 0; x < xResultsMax; x += 4) {
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 4);
 				}
 				yResults[y] = xResults;
 			}

--- a/bin/gpu-browser-core.min.js
+++ b/bin/gpu-browser-core.min.js
@@ -5,7 +5,7 @@
  * GPU Accelerated JavaScript
  *
  * @version 2.0.0-rc.12
- * @date Fri Apr 26 2019 22:06:15 GMT-0400 (Eastern Daylight Time)
+ * @date Sun Apr 28 2019 15:00:28 GMT+0200 (CEST)
  *
  * @license MIT
  * The MIT License
@@ -18,7 +18,7 @@
  * GPU Accelerated JavaScript
  *
  * @version 2.0.0-rc.12
- * @date Fri Apr 26 2019 22:06:12 GMT-0400 (Eastern Daylight Time)
+ * @date Sun Apr 28 2019 15:00:27 GMT+0200 (CEST)
  *
  * @license MIT
  * The MIT License
@@ -3463,9 +3463,10 @@ class GLKernel extends Kernel {
 		const XResultsMax = xMax * 4;
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * XResultsMax;
 			let i = 0;
 			for (let x = 0; x < XResultsMax; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 2);
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 2);
 			}
 			yResults[y] = xResults;
 		}
@@ -3480,9 +3481,10 @@ class GLKernel extends Kernel {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
 				for (let x = 0; x < xResultsMax; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 2);
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 2);
 				}
 				yResults[y] = xResults;
 			}
@@ -3504,13 +3506,14 @@ class GLKernel extends Kernel {
 	render2DArray3() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax] = this.output;
-		const xMaxResults = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const yResults = new Array(yMax);
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * xResultsMax;
 			let i = 0;
-			for (let x = 0; x < xMaxResults; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 3);
+			for (let x = 0; x < xResultsMax; x += 4) {
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 3);
 			}
 			yResults[y] = xResults;
 		}
@@ -3519,15 +3522,16 @@ class GLKernel extends Kernel {
 	render3DArray3() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax, zMax] = this.output;
-		const xMaxResults = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const zResults = new Array(zMax);
 		for (let z = 0; z < zMax; z++) {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
-				for (let x = 0; x < xMaxResults; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 3);
+				for (let x = 0; x < xResultsMax; x += 4) {
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 3);
 				}
 				yResults[y] = xResults;
 			}
@@ -3549,13 +3553,14 @@ class GLKernel extends Kernel {
 	render2DArray4() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax] = this.output;
-		const xMaxResult = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const yResults = new Array(yMax);
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * xResultsMax;
 			let i = 0;
-			for (let x = 0; x < xMaxResult; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 4);
+			for (let x = 0; x < xResultsMax; x += 4) {
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 4);
 			}
 			yResults[y] = xResults;
 		}
@@ -3564,15 +3569,16 @@ class GLKernel extends Kernel {
 	render3DArray4() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax, zMax] = this.output;
-		const xResultsMap = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const zResults = new Array(zMax);
 		for (let z = 0; z < zMax; z++) {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
-				for (let x = 0; x < xResultsMap; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 4);
+				for (let x = 0; x < xResultsMax; x += 4) {
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 4);
 				}
 				yResults[y] = xResults;
 			}

--- a/bin/gpu-browser.js
+++ b/bin/gpu-browser.js
@@ -5,7 +5,7 @@
  * GPU Accelerated JavaScript
  *
  * @version 2.0.0-rc.12
- * @date Fri Apr 26 2019 22:06:12 GMT-0400 (Eastern Daylight Time)
+ * @date Sun Apr 28 2019 15:00:27 GMT+0200 (CEST)
  *
  * @license MIT
  * The MIT License
@@ -8214,9 +8214,10 @@ class GLKernel extends Kernel {
 		const XResultsMax = xMax * 4;
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * XResultsMax;
 			let i = 0;
 			for (let x = 0; x < XResultsMax; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 2);
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 2);
 			}
 			yResults[y] = xResults;
 		}
@@ -8231,9 +8232,10 @@ class GLKernel extends Kernel {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
 				for (let x = 0; x < xResultsMax; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 2);
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 2);
 				}
 				yResults[y] = xResults;
 			}
@@ -8255,13 +8257,14 @@ class GLKernel extends Kernel {
 	render2DArray3() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax] = this.output;
-		const xMaxResults = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const yResults = new Array(yMax);
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * xResultsMax;
 			let i = 0;
-			for (let x = 0; x < xMaxResults; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 3);
+			for (let x = 0; x < xResultsMax; x += 4) {
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 3);
 			}
 			yResults[y] = xResults;
 		}
@@ -8270,15 +8273,16 @@ class GLKernel extends Kernel {
 	render3DArray3() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax, zMax] = this.output;
-		const xMaxResults = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const zResults = new Array(zMax);
 		for (let z = 0; z < zMax; z++) {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
-				for (let x = 0; x < xMaxResults; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 3);
+				for (let x = 0; x < xResultsMax; x += 4) {
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 3);
 				}
 				yResults[y] = xResults;
 			}
@@ -8300,13 +8304,14 @@ class GLKernel extends Kernel {
 	render2DArray4() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax] = this.output;
-		const xMaxResult = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const yResults = new Array(yMax);
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * xResultsMax;
 			let i = 0;
-			for (let x = 0; x < xMaxResult; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 4);
+			for (let x = 0; x < xResultsMax; x += 4) {
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 4);
 			}
 			yResults[y] = xResults;
 		}
@@ -8315,15 +8320,16 @@ class GLKernel extends Kernel {
 	render3DArray4() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax, zMax] = this.output;
-		const xResultsMap = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const zResults = new Array(zMax);
 		for (let z = 0; z < zMax; z++) {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
-				for (let x = 0; x < xResultsMap; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 4);
+				for (let x = 0; x < xResultsMax; x += 4) {
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 4);
 				}
 				yResults[y] = xResults;
 			}

--- a/bin/gpu-browser.min.js
+++ b/bin/gpu-browser.min.js
@@ -5,7 +5,7 @@
  * GPU Accelerated JavaScript
  *
  * @version 2.0.0-rc.12
- * @date Fri Apr 26 2019 22:06:15 GMT-0400 (Eastern Daylight Time)
+ * @date Sun Apr 28 2019 15:00:28 GMT+0200 (CEST)
  *
  * @license MIT
  * The MIT License
@@ -18,7 +18,7 @@
  * GPU Accelerated JavaScript
  *
  * @version 2.0.0-rc.12
- * @date Fri Apr 26 2019 22:06:12 GMT-0400 (Eastern Daylight Time)
+ * @date Sun Apr 28 2019 15:00:27 GMT+0200 (CEST)
  *
  * @license MIT
  * The MIT License
@@ -8227,9 +8227,10 @@ class GLKernel extends Kernel {
 		const XResultsMax = xMax * 4;
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * XResultsMax;
 			let i = 0;
 			for (let x = 0; x < XResultsMax; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 2);
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 2);
 			}
 			yResults[y] = xResults;
 		}
@@ -8244,9 +8245,10 @@ class GLKernel extends Kernel {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
 				for (let x = 0; x < xResultsMax; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 2);
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 2);
 				}
 				yResults[y] = xResults;
 			}
@@ -8268,13 +8270,14 @@ class GLKernel extends Kernel {
 	render2DArray3() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax] = this.output;
-		const xMaxResults = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const yResults = new Array(yMax);
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * xResultsMax;
 			let i = 0;
-			for (let x = 0; x < xMaxResults; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 3);
+			for (let x = 0; x < xResultsMax; x += 4) {
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 3);
 			}
 			yResults[y] = xResults;
 		}
@@ -8283,15 +8286,16 @@ class GLKernel extends Kernel {
 	render3DArray3() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax, zMax] = this.output;
-		const xMaxResults = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const zResults = new Array(zMax);
 		for (let z = 0; z < zMax; z++) {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
-				for (let x = 0; x < xMaxResults; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 3);
+				for (let x = 0; x < xResultsMax; x += 4) {
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 3);
 				}
 				yResults[y] = xResults;
 			}
@@ -8313,13 +8317,14 @@ class GLKernel extends Kernel {
 	render2DArray4() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax] = this.output;
-		const xMaxResult = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const yResults = new Array(yMax);
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * xResultsMax;
 			let i = 0;
-			for (let x = 0; x < xMaxResult; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 4);
+			for (let x = 0; x < xResultsMax; x += 4) {
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 4);
 			}
 			yResults[y] = xResults;
 		}
@@ -8328,15 +8333,16 @@ class GLKernel extends Kernel {
 	render3DArray4() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax, zMax] = this.output;
-		const xResultsMap = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const zResults = new Array(zMax);
 		for (let z = 0; z < zMax; z++) {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
-				for (let x = 0; x < xResultsMap; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 4);
+				for (let x = 0; x < xResultsMax; x += 4) {
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 4);
 				}
 				yResults[y] = xResults;
 			}

--- a/src/backend/gl-kernel.js
+++ b/src/backend/gl-kernel.js
@@ -752,9 +752,10 @@ class GLKernel extends Kernel {
 		const XResultsMax = xMax * 4;
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * XResultsMax;
 			let i = 0;
 			for (let x = 0; x < XResultsMax; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 2);
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 2);
 			}
 			yResults[y] = xResults;
 		}
@@ -769,9 +770,10 @@ class GLKernel extends Kernel {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
 				for (let x = 0; x < xResultsMax; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 2);
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 2);
 				}
 				yResults[y] = xResults;
 			}
@@ -793,13 +795,14 @@ class GLKernel extends Kernel {
 	render2DArray3() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax] = this.output;
-		const xMaxResults = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const yResults = new Array(yMax);
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * xResultsMax;
 			let i = 0;
-			for (let x = 0; x < xMaxResults; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 3);
+			for (let x = 0; x < xResultsMax; x += 4) {
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 3);
 			}
 			yResults[y] = xResults;
 		}
@@ -808,15 +811,16 @@ class GLKernel extends Kernel {
 	render3DArray3() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax, zMax] = this.output;
-		const xMaxResults = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const zResults = new Array(zMax);
 		for (let z = 0; z < zMax; z++) {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
-				for (let x = 0; x < xMaxResults; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 3);
+				for (let x = 0; x < xResultsMax; x += 4) {
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 3);
 				}
 				yResults[y] = xResults;
 			}
@@ -838,13 +842,14 @@ class GLKernel extends Kernel {
 	render2DArray4() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax] = this.output;
-		const xMaxResult = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const yResults = new Array(yMax);
 		for (let y = 0; y < yMax; y++) {
 			const xResults = new Array(xMax);
+			const offset = y * xResultsMax;
 			let i = 0;
-			for (let x = 0; x < xMaxResult; x += 4) {
-				xResults[i++] = pixels.subarray(x, x + 4);
+			for (let x = 0; x < xResultsMax; x += 4) {
+				xResults[i++] = pixels.subarray(x + offset, x + offset + 4);
 			}
 			yResults[y] = xResults;
 		}
@@ -853,15 +858,16 @@ class GLKernel extends Kernel {
 	render3DArray4() {
 		const pixels = this.readFloatPixelsToFloat32Array();
 		const [xMax, yMax, zMax] = this.output;
-		const xResultsMap = xMax * 4;
+		const xResultsMax = xMax * 4;
 		const zResults = new Array(zMax);
 		for (let z = 0; z < zMax; z++) {
 			const yResults = new Array(yMax);
 			for (let y = 0; y < yMax; y++) {
 				const xResults = new Array(xMax);
+				const offset = (z * xResultsMax * yMax) + (y * xResultsMax);
 				let i = 0;
-				for (let x = 0; x < xResultsMap; x += 4) {
-					xResults[i++] = pixels.subarray(x, x + 4);
+				for (let x = 0; x < xResultsMax; x += 4) {
+					xResults[i++] = pixels.subarray(x + offset, x + offset + 4);
 				}
 				yResults[y] = xResults;
 			}

--- a/test/features/return-arrays.js
+++ b/test/features/return-arrays.js
@@ -40,10 +40,15 @@ test('return Array(2) from kernel cpu', () => {
 function returnArray2D2FromKernel(mode) {
   const gpu = new GPU({ mode });
   const kernel = gpu.createKernel(function() {
-    return [1, 2];
-  }, { output: [2, 2], precision: 'single' });
-  const result = kernel();
-  assert.deepEqual(result.map(matrix => matrix.map(row => Array.from(row))), [[[1, 2], [1, 2]],[[1, 2], [1, 2]]]);
+    return [this.thread.x, this.thread.y];
+  }, { output : [3, 7], precision: 'single' });
+  const res = kernel();
+  for (let y = 0; y < 7; ++y) {
+    for (let x = 0; x < 3; ++x) {
+        assert.equal(res[y][x][0], x);
+        assert.equal(res[y][x][1], y);
+    }
+  }
   gpu.destroy();
 }
 
@@ -73,11 +78,18 @@ test('return Array2D(2) from kernel cpu', () => {
 
 function returnArray3D2FromKernel(mode) {
   const gpu = new GPU({ mode });
-  const kernel = gpu.createKernel(function() {
-    return [1, 2];
-  }, { output: [2, 2, 2], precision: 'single' });
-  const result = kernel();
-  assert.deepEqual(result.map(cube => cube.map(matrix => matrix.map(row => Array.from(row)))), [[[[1, 2], [1, 2]],[[1, 2], [1, 2]]],[[[1, 2], [1, 2]],[[1, 2], [1, 2]]]]);
+const kernel = gpu.createKernel(function() {
+    return [this.thread.y, this.thread.z];
+  }, { output : [3, 5, 7], precision: 'single' });
+  const res = kernel();
+  for (let z = 0; z < 7; ++z) {
+    for (let y = 0; y < 5; ++y) {
+      for (let x = 0; x < 3; ++x) {
+        assert.equal(res[z][y][x][0], y);
+        assert.equal(res[z][y][x][1], z);
+      }
+    }
+  }
   gpu.destroy();
 }
 
@@ -143,10 +155,16 @@ test('return Array(3) from kernel cpu', () => {
 function returnArray2D3FromKernel(mode) {
   const gpu = new GPU({ mode });
   const kernel = gpu.createKernel(function() {
-    return [1, 2, 3];
-  }, { output: [2,2], precision: 'single' });
-  const result = kernel();
-  assert.deepEqual(Array.from(result.map(matrix => matrix.map(row => Array.from(row)))), [[[1, 2, 3],[1, 2, 3]],[[1, 2, 3],[1, 2, 3]]]);
+    return [this.thread.x, this.thread.y, this.thread.x * this.thread.y];
+  }, { output : [3, 7] ,precision: 'single' });
+  const res = kernel();
+  for (let y = 0; y < 7; ++y) {
+    for (let x = 0; x < 3; ++x) {
+        assert.equal(res[y][x][0], x);
+        assert.equal(res[y][x][1], y);
+        assert.equal(res[y][x][2], x * y);
+    }
+  }
   gpu.destroy();
 }
 
@@ -177,10 +195,18 @@ test('return Array2D(3) from kernel cpu', () => {
 function returnArray3D3FromKernel(mode) {
   const gpu = new GPU({ mode });
   const kernel = gpu.createKernel(function() {
-    return [1, 2, 3];
-  }, { output: [2,2,2], precision: 'single' });
-  const result = kernel();
-  assert.deepEqual(Array.from(result.map(cube => cube.map(matrix => matrix.map(row => Array.from(row))))), [[[[1, 2, 3],[1, 2, 3]],[[1, 2, 3],[1, 2, 3]]],[[[1, 2, 3],[1, 2, 3]],[[1, 2, 3],[1, 2, 3]]]]);
+    return [this.thread.x, this.thread.y, this.thread.z];
+  }, { output : [3, 5, 7] ,precision: 'single' });
+  const res = kernel();
+  for (let z = 0; z < 7; ++z) {
+    for (let y = 0; y < 5; ++y) {
+      for (let x = 0; x < 3; ++x) {
+        assert.equal(res[z][y][x][0], x);
+        assert.equal(res[z][y][x][1], y);
+        assert.equal(res[z][y][x][2], z);
+      }
+    }
+  }
   gpu.destroy();
 }
 
@@ -245,10 +271,17 @@ test('return Array(4) from kernel cpu', () => {
 function returnArray2D4FromKernel(mode) {
   const gpu = new GPU({ mode });
   const kernel = gpu.createKernel(function() {
-    return [1, 2, 3, 4];
-  }, { output: [2,2], precision: 'single' });
-  const result = kernel();
-  assert.deepEqual(result.map(matrix => matrix.map(row => Array.from(row))), [[[1, 2, 3, 4],[1, 2, 3, 4]],[[1, 2, 3, 4],[1, 2, 3, 4]]]);
+    return [this.thread.x, this.thread.y, this.thread.x * this.thread.y, this.thread.x - this.thread.y];
+  }, { output : [3, 7], precision: 'single' });
+  const res = kernel();
+  for (let y = 0; y < 3; ++y) {
+    for (let x = 0; x < 3; ++x) {
+        assert.equal(res[y][x][0], x);
+        assert.equal(res[y][x][1], y);
+        assert.equal(res[y][x][2], x * y);
+        assert.equal(res[y][x][3], x - y);
+    }
+  }
   gpu.destroy();
 }
 
@@ -279,10 +312,19 @@ test('return Array2D(4) from kernel cpu', () => {
 function returnArray3D4FromKernel(mode) {
   const gpu = new GPU({ mode });
   const kernel = gpu.createKernel(function() {
-    return [1, 2, 3, 4];
-  }, { output: [2,2,2], precision: 'single' });
-  const result = kernel();
-  assert.deepEqual(result.map(cube => cube.map(matrix => matrix.map(row => Array.from(row)))), [[[[1, 2, 3, 4],[1, 2, 3, 4]],[[1, 2, 3, 4],[1, 2, 3, 4]]],[[[1, 2, 3, 4],[1, 2, 3, 4]],[[1, 2, 3, 4],[1, 2, 3, 4]]]]);
+    return [this.thread.x, this.thread.y, this.thread.z, this.thread.x * this.thread.y * this.thread.z];
+  }, { output : [3, 5, 7], precision: 'single' });
+  const res = kernel();
+  for (let z = 0; z < 7; ++z) {
+    for (let y = 0; y < 5; ++y) {
+      for (let x = 0; x < 3; ++x) {
+        assert.equal(res[z][y][x][0], x);
+        assert.equal(res[z][y][x][1], y);
+        assert.equal(res[z][y][x][2], z);
+        assert.equal(res[z][y][x][3], x * y * z);
+      }
+    }
+  }
   gpu.destroy();
 }
 


### PR DESCRIPTION
The return-arrays.js tests are updated to have non-square output sizes and for each output to have a unique value.

I also renamed all variables (which I assume are supposed to be the same thing) to `xResultsMax`.
