### PR TITLE
Fix calls to FunctionNode.astErrorOutput, it's not a constructor

### DIFF
--- a/src/backend/cpu/function-node.js
+++ b/src/backend/cpu/function-node.js
@@ -282,7 +282,7 @@ class CPUFunctionNode extends FunctionNode {
   astAssignmentExpression(assNode, retArr) {
     const declaration = this.getDeclaration(assNode.left);
     if (declaration && !declaration.assignable) {
-      throw new this.astErrorOutput(`Variable ${assNode.left.name} is not assignable here`, assNode);
+      throw this.astErrorOutput(`Variable ${assNode.left.name} is not assignable here`, assNode);
     }
     this.astGeneric(assNode.left, retArr);
     retArr.push(assNode.operator);

--- a/src/backend/web-gl/function-node.js
+++ b/src/backend/web-gl/function-node.js
@@ -743,7 +743,7 @@ class WebGLFunctionNode extends FunctionNode {
   astAssignmentExpression(assNode, retArr) {
     const declaration = this.getDeclaration(assNode.left);
     if (declaration && !declaration.assignable) {
-      throw new this.astErrorOutput(`Variable ${assNode.left.name} is not assignable here`, assNode);
+      throw this.astErrorOutput(`Variable ${assNode.left.name} is not assignable here`, assNode);
     }
     // TODO: casting needs implemented here
     if (assNode.operator === '%=') {


### PR DESCRIPTION
Sorry I don't have a repro steps, but after upgrading from v1 I'm getting `TypeError: this.astErrorOutput is not a constructor`.