### PR TITLE
fix: define args of validateSettings() function

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -197,7 +197,7 @@ export abstract class Kernel {
   setStrictIntegers(flag: boolean): this;
   addSubKernel(subKernel: ISubKernel): this;
   destroy(removeCanvasReferences?: boolean): void;
-  validateSettings(IArguments): void;
+  validateSettings(args: IArguments): void;
 }
 
 export type Precision = 'single' | 'unsigned';


### PR DESCRIPTION
Hi everyone, I noticed a little glitch in the TypeScript definition file. The definition of the `validateSettings()` function of the `Kernel` was missing a parameter definition. I guess this was a typo.

Please let me know if I should change something to make this pull request mergeable.