### PR TITLE
add browser field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "unpkg": "./dist/gpu-browser.min.js",
   "jsdelivr": "./dist/gpu-browser.min.js",
+  "browser": "./dist/gpu-browser.js",
   "directories": {
     "doc": "doc",
     "test": "test"


### PR DESCRIPTION
This pull request add a browser field to the package.json which points to the browser bundle.

It fixes #509.