### PR TITLE
Add cdn links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ You can experiment around with the [kernel playground here](http://gpu.rocks/pla
 Matrix multiplication (perform matrix multiplication on 2 matrices of size 512 x 512) written in GPU.js:
 
 ## Browser
-
 ```html
 <script src="dist/gpu-browser.min.js"></script>
 <script>
@@ -39,7 +38,6 @@ Matrix multiplication (perform matrix multiplication on 2 matrices of size 512 x
 ```
 
 ## CDN
-
 ``` 
 https://unpkg.com/gpu.js@latest/dist/gpu-browser.min.js
 https://cdn.jsdelivr.net/npm/gpu.js@latest/dist/gpu-browser.min.js

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ You can experiment around with the [kernel playground here](http://gpu.rocks/pla
 Matrix multiplication (perform matrix multiplication on 2 matrices of size 512 x 512) written in GPU.js:
 
 ## Browser
+
 ```html
 <script src="dist/gpu-browser.min.js"></script>
 <script>
@@ -35,6 +36,13 @@ Matrix multiplication (perform matrix multiplication on 2 matrices of size 512 x
 
     const c = multiplyMatrix(a, b);
 </script>
+```
+
+## CDN
+
+``` 
+https://unpkg.com/gpu.js@latest/dist/gpu-browser.min.js
+https://cdn.jsdelivr.net/npm/gpu.js@latest/dist/gpu-browser.min.js
 ```
 
 ## Node


### PR DESCRIPTION
When I began using this package I struggled with the NPM Install process, as it has python dependencies in the rebuild process.

I did not realize that this package was automatically available via CDN