### PR TITLE
Improve examples for loading images via HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,11 +437,13 @@ const kernel = gpu.createKernel(function(image) {
   .setGraphical(true)
   .setOutput([100, 100]);
 
-const image = new document.createElement('img');
+const image = document.createElement('img');
 image.src = 'my/image/source.png';
 image.onload = () => {
   kernel(image);
   // Result: colorful image
+  
+  document.getElementsByTagName('body')[0].appendChild(kernel.getCanvas());
 };
 ```
 
@@ -455,13 +457,13 @@ const kernel = gpu.createKernel(function(image) {
   .setGraphical(true)
   .setOutput([100, 100]);
 
-const image1 = new document.createElement('img');
+const image1 = document.createElement('img');
 image1.src = 'my/image/source1.png';
 image1.onload = onload;
-const image2 = new document.createElement('img');
+const image2 = document.createElement('img');
 image2.src = 'my/image/source2.png';
 image2.onload = onload;
-const image3 = new document.createElement('img');
+const image3 = document.createElement('img');
 image3.src = 'my/image/source3.png';
 image3.onload = onload;
 const totalImages = 3;
@@ -471,6 +473,8 @@ function onload() {
   if (loadedImages === totalImages) {
     kernel([image1, image2, image3]);
     // Result: colorful image composed of many images
+
+     document.getElementsByTagName('body')[0].appendChild(kernel.getCanvas());
   }
 };
 ```

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ image.onload = () => {
   kernel(image);
   // Result: colorful image
   
-  document.getElementsByTagName('body')[0].appendChild(kernel.getCanvas());
+  document.getElementsByTagName('body')[0].appendChild(kernel.canvas);
 };
 ```
 
@@ -474,7 +474,7 @@ function onload() {
     kernel([image1, image2, image3]);
     // Result: colorful image composed of many images
 
-     document.getElementsByTagName('body')[0].appendChild(kernel.getCanvas());
+     document.getElementsByTagName('body')[0].appendChild(kernel.canvas);
   }
 };
 ```


### PR DESCRIPTION
While following the documentation to load an image, there were some errors in the way `document.createElement` was called.

Furthermore it was unclear how to display the resulting output. (I know its already there, but in different section. It's nice when example can be copy/pasted and work end to end)