### PR TITLE
Add support for type Uint8ClampedArray in KernelVariable

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -407,6 +407,7 @@ export type KernelVariable =
   | Uint8Array
   | Uint16Array
   | Uint32Array
+  | Uint8ClampedArray
   | KernelOutput;
 
 export type ThreadFunctionResult


### PR DESCRIPTION
```
render = new GPU.GPU({ mode: "gpu" })
render(image.data, 14 * Math.sin(Date.now() / 400))
```
In the above mentioned example since image data is of type Uint8ClampedArray & KernelVariable does not support the same hence gives type error


Ex: https://observablehq.com/@fil/image-to-gpu