### PR TITLE
Add Skypack to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Matrix multiplication (perform matrix multiplication on 2 matrices of size 512 x
 ``` 
 https://unpkg.com/gpu.js@latest/dist/gpu-browser.min.js
 https://cdn.jsdelivr.net/npm/gpu.js@latest/dist/gpu-browser.min.js
-import {GPU} from 'https://cdn.skypack.dev/gpu.js';
+import {GPU} from 'https://cdn.skypack.dev/gpu.js@latest';
 ```
 
 ## Node

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Matrix multiplication (perform matrix multiplication on 2 matrices of size 512 x
 ``` 
 https://unpkg.com/gpu.js@latest/dist/gpu-browser.min.js
 https://cdn.jsdelivr.net/npm/gpu.js@latest/dist/gpu-browser.min.js
+import {GPU} from 'https://cdn.skypack.dev/gpu.js';
 ```
 
 ## Node


### PR DESCRIPTION
[Skypack](https://www.skypack.dev) is a popular CDN for importing packages directly in the browser with ESM import syntax. For a lot of users, this syntax is more explicit and more familiar than the older, implicit script tag.

I added a full import snippet here for easier copy-pasting, but also happy to replace with just the URL.

You can also run this quickly in your browser devtools via: `const pkg = await import('https://cdn.skypack.dev/gpu.js');`