### PR TITLE
Remove trailing commas

### DIFF
--- a/dist/gpu-browser-core.js
+++ b/dist/gpu-browser-core.js
@@ -11229,7 +11229,7 @@ float integerCorrectionModulo(float number, float divisor) {
     result.push(
       '  threadId = indexTo3D(index, uOutputDim)',
       '  kernel()',
-      `  gl_FragData[0].${channel} = kernelResult`,
+      `  gl_FragData[0].${channel} = kernelResult`
     );
   }
 
@@ -11239,11 +11239,11 @@ float integerCorrectionModulo(float number, float divisor) {
       const subKernel = this.subKernels[i];
       if (subKernel.returnType === 'Integer') {
         result.push(
-          `  gl_FragData[${i + 1}].${channel} = float(subKernelResult_${this.subKernels[i].name})`,
+          `  gl_FragData[${i + 1}].${channel} = float(subKernelResult_${this.subKernels[i].name})`
         );
       } else {
         result.push(
-          `  gl_FragData[${i + 1}].${channel} = subKernelResult_${this.subKernels[i].name}`,
+          `  gl_FragData[${i + 1}].${channel} = subKernelResult_${this.subKernels[i].name}`
         );
       }
     }
@@ -11264,11 +11264,11 @@ float integerCorrectionModulo(float number, float divisor) {
       const subKernel = this.subKernels[i];
       if (subKernel.returnType === 'Integer') {
         result.push(
-          `  gl_FragData[${i + 1}][0] = float(subKernelResult_${subKernel.name})`,
+          `  gl_FragData[${i + 1}][0] = float(subKernelResult_${subKernel.name})`
         );
       } else {
         result.push(
-          `  gl_FragData[${i + 1}][0] = subKernelResult_${subKernel.name}`,
+          `  gl_FragData[${i + 1}][0] = subKernelResult_${subKernel.name}`
         );
       }
     }
@@ -11290,7 +11290,7 @@ float integerCorrectionModulo(float number, float divisor) {
     for (let i = 0; i < this.subKernels.length; ++i) {
       result.push(
         `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
-        `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
+        `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`
       );
     }
     return result;
@@ -11313,7 +11313,7 @@ float integerCorrectionModulo(float number, float divisor) {
       result.push(
         `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
         `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
-        `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`,
+        `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`
       );
     }
     return result;
@@ -11338,11 +11338,11 @@ float integerCorrectionModulo(float number, float divisor) {
           const subKernel = this.subKernels[i];
           if (subKernel.returnType === 'Integer') {
             result.push(
-              `  gl_FragData[${i + 1}] = float(subKernelResult_${this.subKernels[i].name})`,
+              `  gl_FragData[${i + 1}] = float(subKernelResult_${this.subKernels[i].name})`
             );
           } else {
             result.push(
-              `  gl_FragData[${i + 1}] = subKernelResult_${this.subKernels[i].name}`,
+              `  gl_FragData[${i + 1}] = subKernelResult_${this.subKernels[i].name}`
             );
           }
         }
@@ -11351,7 +11351,7 @@ float integerCorrectionModulo(float number, float divisor) {
         for (let i = 0; i < this.subKernels.length; ++i) {
           result.push(
             `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
-            `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
+            `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`
           );
         }
         break;
@@ -11360,7 +11360,7 @@ float integerCorrectionModulo(float number, float divisor) {
           result.push(
             `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
             `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
-            `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`,
+            `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`
           );
         }
         break;
@@ -11370,7 +11370,7 @@ float integerCorrectionModulo(float number, float divisor) {
             `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
             `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
             `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`,
-            `  gl_FragData[${i + 1}][3] = subKernelResult_${this.subKernels[i].name}[3]`,
+            `  gl_FragData[${i + 1}][3] = subKernelResult_${this.subKernels[i].name}[3]`
           );
         }
         break;
@@ -13283,7 +13283,7 @@ class WebGL2Kernel extends WebGLKernel {
     result.push(
       '  threadId = indexTo3D(index, uOutputDim)',
       '  kernel()',
-      `  data0.${channel} = kernelResult`,
+      `  data0.${channel} = kernelResult`
     );
   }
 
@@ -13293,11 +13293,11 @@ class WebGL2Kernel extends WebGLKernel {
       const subKernel = this.subKernels[i];
       if (subKernel.returnType === 'Integer') {
         result.push(
-          `  data${i + 1}.${channel} = float(subKernelResult_${subKernel.name})`,
+          `  data${i + 1}.${channel} = float(subKernelResult_${subKernel.name})`
         );
       } else {
         result.push(
-          `  data${i + 1}.${channel} = subKernelResult_${subKernel.name}`,
+          `  data${i + 1}.${channel} = subKernelResult_${subKernel.name}`
         );
       }
     }
@@ -13318,11 +13318,11 @@ class WebGL2Kernel extends WebGLKernel {
       const subKernel = this.subKernels[i];
       if (subKernel.returnType === 'Integer') {
         result.push(
-          `  data${i + 1}[0] = float(subKernelResult_${subKernel.name})`,
+          `  data${i + 1}[0] = float(subKernelResult_${subKernel.name})`
         );
       } else {
         result.push(
-          `  data${i + 1}[0] = subKernelResult_${subKernel.name}`,
+          `  data${i + 1}[0] = subKernelResult_${subKernel.name}`
         );
       }
     }
@@ -13345,7 +13345,7 @@ class WebGL2Kernel extends WebGLKernel {
       const subKernel = this.subKernels[i];
       result.push(
         `  data${i + 1}[0] = subKernelResult_${subKernel.name}[0]`,
-        `  data${i + 1}[1] = subKernelResult_${subKernel.name}[1]`,
+        `  data${i + 1}[1] = subKernelResult_${subKernel.name}[1]`
       );
     }
     return result;
@@ -13369,7 +13369,7 @@ class WebGL2Kernel extends WebGLKernel {
       result.push(
         `  data${i + 1}[0] = subKernelResult_${subKernel.name}[0]`,
         `  data${i + 1}[1] = subKernelResult_${subKernel.name}[1]`,
-        `  data${i + 1}[2] = subKernelResult_${subKernel.name}[2]`,
+        `  data${i + 1}[2] = subKernelResult_${subKernel.name}[2]`
       );
     }
     return result;
@@ -13388,7 +13388,7 @@ class WebGL2Kernel extends WebGLKernel {
     if (!this.subKernels) return result;
     for (let i = 0; i < this.subKernels.length; ++i) {
       result.push(
-        `  data${i + 1} = subKernelResult_${this.subKernels[i].name}`,
+        `  data${i + 1} = subKernelResult_${this.subKernels[i].name}`
       );
     }
     return result;

--- a/dist/gpu-browser.js
+++ b/dist/gpu-browser.js
@@ -15838,7 +15838,7 @@ float integerCorrectionModulo(float number, float divisor) {
     result.push(
       '  threadId = indexTo3D(index, uOutputDim)',
       '  kernel()',
-      `  gl_FragData[0].${channel} = kernelResult`,
+      `  gl_FragData[0].${channel} = kernelResult`
     );
   }
 
@@ -15848,11 +15848,11 @@ float integerCorrectionModulo(float number, float divisor) {
       const subKernel = this.subKernels[i];
       if (subKernel.returnType === 'Integer') {
         result.push(
-          `  gl_FragData[${i + 1}].${channel} = float(subKernelResult_${this.subKernels[i].name})`,
+          `  gl_FragData[${i + 1}].${channel} = float(subKernelResult_${this.subKernels[i].name})`
         );
       } else {
         result.push(
-          `  gl_FragData[${i + 1}].${channel} = subKernelResult_${this.subKernels[i].name}`,
+          `  gl_FragData[${i + 1}].${channel} = subKernelResult_${this.subKernels[i].name}`
         );
       }
     }
@@ -15873,11 +15873,11 @@ float integerCorrectionModulo(float number, float divisor) {
       const subKernel = this.subKernels[i];
       if (subKernel.returnType === 'Integer') {
         result.push(
-          `  gl_FragData[${i + 1}][0] = float(subKernelResult_${subKernel.name})`,
+          `  gl_FragData[${i + 1}][0] = float(subKernelResult_${subKernel.name})`
         );
       } else {
         result.push(
-          `  gl_FragData[${i + 1}][0] = subKernelResult_${subKernel.name}`,
+          `  gl_FragData[${i + 1}][0] = subKernelResult_${subKernel.name}`
         );
       }
     }
@@ -15899,7 +15899,7 @@ float integerCorrectionModulo(float number, float divisor) {
     for (let i = 0; i < this.subKernels.length; ++i) {
       result.push(
         `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
-        `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
+        `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`
       );
     }
     return result;
@@ -15922,7 +15922,7 @@ float integerCorrectionModulo(float number, float divisor) {
       result.push(
         `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
         `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
-        `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`,
+        `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`
       );
     }
     return result;
@@ -15947,11 +15947,11 @@ float integerCorrectionModulo(float number, float divisor) {
           const subKernel = this.subKernels[i];
           if (subKernel.returnType === 'Integer') {
             result.push(
-              `  gl_FragData[${i + 1}] = float(subKernelResult_${this.subKernels[i].name})`,
+              `  gl_FragData[${i + 1}] = float(subKernelResult_${this.subKernels[i].name})`
             );
           } else {
             result.push(
-              `  gl_FragData[${i + 1}] = subKernelResult_${this.subKernels[i].name}`,
+              `  gl_FragData[${i + 1}] = subKernelResult_${this.subKernels[i].name}`
             );
           }
         }
@@ -15960,7 +15960,7 @@ float integerCorrectionModulo(float number, float divisor) {
         for (let i = 0; i < this.subKernels.length; ++i) {
           result.push(
             `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
-            `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
+            `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`
           );
         }
         break;
@@ -15969,7 +15969,7 @@ float integerCorrectionModulo(float number, float divisor) {
           result.push(
             `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
             `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
-            `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`,
+            `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`
           );
         }
         break;
@@ -15979,7 +15979,7 @@ float integerCorrectionModulo(float number, float divisor) {
             `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
             `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
             `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`,
-            `  gl_FragData[${i + 1}][3] = subKernelResult_${this.subKernels[i].name}[3]`,
+            `  gl_FragData[${i + 1}][3] = subKernelResult_${this.subKernels[i].name}[3]`
           );
         }
         break;
@@ -17892,7 +17892,7 @@ class WebGL2Kernel extends WebGLKernel {
     result.push(
       '  threadId = indexTo3D(index, uOutputDim)',
       '  kernel()',
-      `  data0.${channel} = kernelResult`,
+      `  data0.${channel} = kernelResult`
     );
   }
 
@@ -17902,11 +17902,11 @@ class WebGL2Kernel extends WebGLKernel {
       const subKernel = this.subKernels[i];
       if (subKernel.returnType === 'Integer') {
         result.push(
-          `  data${i + 1}.${channel} = float(subKernelResult_${subKernel.name})`,
+          `  data${i + 1}.${channel} = float(subKernelResult_${subKernel.name})`
         );
       } else {
         result.push(
-          `  data${i + 1}.${channel} = subKernelResult_${subKernel.name}`,
+          `  data${i + 1}.${channel} = subKernelResult_${subKernel.name}`
         );
       }
     }
@@ -17927,11 +17927,11 @@ class WebGL2Kernel extends WebGLKernel {
       const subKernel = this.subKernels[i];
       if (subKernel.returnType === 'Integer') {
         result.push(
-          `  data${i + 1}[0] = float(subKernelResult_${subKernel.name})`,
+          `  data${i + 1}[0] = float(subKernelResult_${subKernel.name})`
         );
       } else {
         result.push(
-          `  data${i + 1}[0] = subKernelResult_${subKernel.name}`,
+          `  data${i + 1}[0] = subKernelResult_${subKernel.name}`
         );
       }
     }
@@ -17954,7 +17954,7 @@ class WebGL2Kernel extends WebGLKernel {
       const subKernel = this.subKernels[i];
       result.push(
         `  data${i + 1}[0] = subKernelResult_${subKernel.name}[0]`,
-        `  data${i + 1}[1] = subKernelResult_${subKernel.name}[1]`,
+        `  data${i + 1}[1] = subKernelResult_${subKernel.name}[1]`
       );
     }
     return result;
@@ -17978,7 +17978,7 @@ class WebGL2Kernel extends WebGLKernel {
       result.push(
         `  data${i + 1}[0] = subKernelResult_${subKernel.name}[0]`,
         `  data${i + 1}[1] = subKernelResult_${subKernel.name}[1]`,
-        `  data${i + 1}[2] = subKernelResult_${subKernel.name}[2]`,
+        `  data${i + 1}[2] = subKernelResult_${subKernel.name}[2]`
       );
     }
     return result;
@@ -17997,7 +17997,7 @@ class WebGL2Kernel extends WebGLKernel {
     if (!this.subKernels) return result;
     for (let i = 0; i < this.subKernels.length; ++i) {
       result.push(
-        `  data${i + 1} = subKernelResult_${this.subKernels[i].name}`,
+        `  data${i + 1} = subKernelResult_${this.subKernels[i].name}`
       );
     }
     return result;

--- a/src/backend/cpu/kernel-string.js
+++ b/src/backend/cpu/kernel-string.js
@@ -37,14 +37,14 @@ function cpuKernelString(cpuKernel, name) {
     '  const { context, canvas, constants: incomingConstants } = settings;',
     `  const output = new Int32Array(${JSON.stringify(Array.from(cpuKernel.output))});`,
     `  const _constantTypes = ${JSON.stringify(cpuKernel.constantTypes)};`,
-    `  const _constants = ${constantsToString(cpuKernel.constants, cpuKernel.constantTypes)};`,
+    `  const _constants = ${constantsToString(cpuKernel.constants, cpuKernel.constantTypes)};`
   );
 
   thisProperties.push(
     '    constants: _constants,',
     '    context,',
     '    output,',
-    '    thread: {x: 0, y: 0, z: 0},',
+    '    thread: {x: 0, y: 0, z: 0},'
   );
 
   if (cpuKernel.graphical) {
@@ -92,7 +92,7 @@ function cpuKernelString(cpuKernel, name) {
     thisProperties.push(
       '    _imageData,',
       '    _colorData,',
-      `    color: ${colorFn},`,
+      `    color: ${colorFn},`
     );
 
     beforeReturn.push(

--- a/src/backend/web-gl/kernel.js
+++ b/src/backend/web-gl/kernel.js
@@ -1297,7 +1297,7 @@ float integerCorrectionModulo(float number, float divisor) {
     result.push(
       '  threadId = indexTo3D(index, uOutputDim)',
       '  kernel()',
-      `  gl_FragData[0].${channel} = kernelResult`,
+      `  gl_FragData[0].${channel} = kernelResult`
     );
   }
 
@@ -1307,11 +1307,11 @@ float integerCorrectionModulo(float number, float divisor) {
       const subKernel = this.subKernels[i];
       if (subKernel.returnType === 'Integer') {
         result.push(
-          `  gl_FragData[${i + 1}].${channel} = float(subKernelResult_${this.subKernels[i].name})`,
+          `  gl_FragData[${i + 1}].${channel} = float(subKernelResult_${this.subKernels[i].name})`
         );
       } else {
         result.push(
-          `  gl_FragData[${i + 1}].${channel} = subKernelResult_${this.subKernels[i].name}`,
+          `  gl_FragData[${i + 1}].${channel} = subKernelResult_${this.subKernels[i].name}`
         );
       }
     }
@@ -1332,11 +1332,11 @@ float integerCorrectionModulo(float number, float divisor) {
       const subKernel = this.subKernels[i];
       if (subKernel.returnType === 'Integer') {
         result.push(
-          `  gl_FragData[${i + 1}][0] = float(subKernelResult_${subKernel.name})`,
+          `  gl_FragData[${i + 1}][0] = float(subKernelResult_${subKernel.name})`
         );
       } else {
         result.push(
-          `  gl_FragData[${i + 1}][0] = subKernelResult_${subKernel.name}`,
+          `  gl_FragData[${i + 1}][0] = subKernelResult_${subKernel.name}`
         );
       }
     }
@@ -1358,7 +1358,7 @@ float integerCorrectionModulo(float number, float divisor) {
     for (let i = 0; i < this.subKernels.length; ++i) {
       result.push(
         `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
-        `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
+        `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`
       );
     }
     return result;
@@ -1381,7 +1381,7 @@ float integerCorrectionModulo(float number, float divisor) {
       result.push(
         `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
         `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
-        `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`,
+        `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`
       );
     }
     return result;
@@ -1406,11 +1406,11 @@ float integerCorrectionModulo(float number, float divisor) {
           const subKernel = this.subKernels[i];
           if (subKernel.returnType === 'Integer') {
             result.push(
-              `  gl_FragData[${i + 1}] = float(subKernelResult_${this.subKernels[i].name})`,
+              `  gl_FragData[${i + 1}] = float(subKernelResult_${this.subKernels[i].name})`
             );
           } else {
             result.push(
-              `  gl_FragData[${i + 1}] = subKernelResult_${this.subKernels[i].name}`,
+              `  gl_FragData[${i + 1}] = subKernelResult_${this.subKernels[i].name}`
             );
           }
         }
@@ -1419,7 +1419,7 @@ float integerCorrectionModulo(float number, float divisor) {
         for (let i = 0; i < this.subKernels.length; ++i) {
           result.push(
             `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
-            `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
+            `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`
           );
         }
         break;
@@ -1428,7 +1428,7 @@ float integerCorrectionModulo(float number, float divisor) {
           result.push(
             `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
             `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
-            `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`,
+            `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`
           );
         }
         break;
@@ -1438,7 +1438,7 @@ float integerCorrectionModulo(float number, float divisor) {
             `  gl_FragData[${i + 1}][0] = subKernelResult_${this.subKernels[i].name}[0]`,
             `  gl_FragData[${i + 1}][1] = subKernelResult_${this.subKernels[i].name}[1]`,
             `  gl_FragData[${i + 1}][2] = subKernelResult_${this.subKernels[i].name}[2]`,
-            `  gl_FragData[${i + 1}][3] = subKernelResult_${this.subKernels[i].name}[3]`,
+            `  gl_FragData[${i + 1}][3] = subKernelResult_${this.subKernels[i].name}[3]`
           );
         }
         break;

--- a/src/backend/web-gl2/kernel.js
+++ b/src/backend/web-gl2/kernel.js
@@ -509,7 +509,7 @@ class WebGL2Kernel extends WebGLKernel {
     result.push(
       '  threadId = indexTo3D(index, uOutputDim)',
       '  kernel()',
-      `  data0.${channel} = kernelResult`,
+      `  data0.${channel} = kernelResult`
     );
   }
 
@@ -519,11 +519,11 @@ class WebGL2Kernel extends WebGLKernel {
       const subKernel = this.subKernels[i];
       if (subKernel.returnType === 'Integer') {
         result.push(
-          `  data${i + 1}.${channel} = float(subKernelResult_${subKernel.name})`,
+          `  data${i + 1}.${channel} = float(subKernelResult_${subKernel.name})`
         );
       } else {
         result.push(
-          `  data${i + 1}.${channel} = subKernelResult_${subKernel.name}`,
+          `  data${i + 1}.${channel} = subKernelResult_${subKernel.name}`
         );
       }
     }
@@ -544,11 +544,11 @@ class WebGL2Kernel extends WebGLKernel {
       const subKernel = this.subKernels[i];
       if (subKernel.returnType === 'Integer') {
         result.push(
-          `  data${i + 1}[0] = float(subKernelResult_${subKernel.name})`,
+          `  data${i + 1}[0] = float(subKernelResult_${subKernel.name})`
         );
       } else {
         result.push(
-          `  data${i + 1}[0] = subKernelResult_${subKernel.name}`,
+          `  data${i + 1}[0] = subKernelResult_${subKernel.name}`
         );
       }
     }
@@ -571,7 +571,7 @@ class WebGL2Kernel extends WebGLKernel {
       const subKernel = this.subKernels[i];
       result.push(
         `  data${i + 1}[0] = subKernelResult_${subKernel.name}[0]`,
-        `  data${i + 1}[1] = subKernelResult_${subKernel.name}[1]`,
+        `  data${i + 1}[1] = subKernelResult_${subKernel.name}[1]`
       );
     }
     return result;
@@ -595,7 +595,7 @@ class WebGL2Kernel extends WebGLKernel {
       result.push(
         `  data${i + 1}[0] = subKernelResult_${subKernel.name}[0]`,
         `  data${i + 1}[1] = subKernelResult_${subKernel.name}[1]`,
-        `  data${i + 1}[2] = subKernelResult_${subKernel.name}[2]`,
+        `  data${i + 1}[2] = subKernelResult_${subKernel.name}[2]`
       );
     }
     return result;
@@ -614,7 +614,7 @@ class WebGL2Kernel extends WebGLKernel {
     if (!this.subKernels) return result;
     for (let i = 0; i < this.subKernels.length; ++i) {
       result.push(
-        `  data${i + 1} = subKernelResult_${this.subKernels[i].name}`,
+        `  data${i + 1} = subKernelResult_${this.subKernels[i].name}`
       );
     }
     return result;


### PR DESCRIPTION
Fix for https://github.com/gpujs/gpu.js/issues/589

For an Angular 7.1 project, the prod build doesn't work, and it is caused by terser at the backend. Specifically the issue described here:

terser/terser#412

There are several examples in GPU.js of result.push('foo','bar','quux',) (note the trailing comma). These need to be removed. I have manually removed them in my local copy of the package (in dist/gpu-browser.js and dist/gpu-browser-core.js) and it builds. These seem to come from several of the source files in the back end. It should be an easy fix.