### PR TITLE
Fix atan2 implementation to behave like Javascript Math.atan2

### DIFF
--- a/src/backend/web-gl/fragment-shader.js
+++ b/src/backend/web-gl/fragment-shader.js
@@ -24,8 +24,12 @@ float asinh(float x) {
 }
 
 float atan2(float v1, float v2) {
-  if (v1 == 0.0 || v2 == 0.0) return 0.0;
-  return atan(v1 / v2);
+  if (v2 == 0.0) {
+    if (v1 == 0.0) return 0.0;
+    if (v1 > 0.0) return 1.5707963267948966;
+    if (v1 < 0.0) return -1.5707963267948966;
+  }
+  return atan(v1, v2);
 }
 
 float atanh(float x) {

--- a/src/backend/web-gl2/fragment-shader.js
+++ b/src/backend/web-gl2/fragment-shader.js
@@ -14,8 +14,12 @@ __CONSTANTS__;
 in vec2 vTexCoord;
 
 float atan2(float v1, float v2) {
-  if (v1 == 0.0 || v2 == 0.0) return 0.0;
-  return atan(v1 / v2);
+  if (v2 == 0.0) {
+    if (v1 == 0.0) return 0.0;
+    if (v1 > 0.0) return 1.5707963267948966;
+    if (v1 < 0.0) return -1.5707963267948966;
+  }
+  return atan(v1, v2);
 }
 
 float cbrt(float x) {

--- a/test/all.html
+++ b/test/all.html
@@ -180,6 +180,7 @@
 <script type="module" src="issues/585-inaccurate-lookups.js"></script>
 <script type="module" src="issues/586-unable-to-resize.js"></script>
 <script type="module" src="issues/608-rewritten-arrays.js"></script>
+<script type="module" src="issues/647-atan2-range.js"></script>
 <script type="module" src="issues/91-create-kernel-map-array.js"></script>
 <script type="module" src="issues/96-param-names.js"></script>
 <script type="module" src="features/to-string/as-file.js"></script>

--- a/test/issues/647-atan2-range.js
+++ b/test/issues/647-atan2-range.js
@@ -1,0 +1,50 @@
+const { assert, skip, test, module: describe } = require('qunit');
+const { GPU } = require('../../src');
+
+describe('issue #647');
+
+function buildAtan2KernelResult(mode) {
+  const gpu = new GPU({ mode });
+  const kernel = gpu.createKernel(function (x, y) {
+    return Math.atan2(y[this.thread.x], x[this.thread.x]);
+  }, {
+    output: [5],
+  });
+
+  // test atan2 at center, E, N, W, S on unit circle
+  // [0,0] [1,0], [0, 1], [-1, 0], [0, -1]
+  const x = [0, 1, 0, -1, 0];
+  const y = [0, 0, 1, 0, -1];
+  const result = kernel(x, y);
+
+  assert.equal(result[0].toFixed(7), 0.0000000);
+  assert.equal(result[1].toFixed(7), 0.0000000);
+  assert.equal(result[2].toFixed(7), 1.5707964);
+  assert.equal(result[3].toFixed(7), 3.1415927);
+  assert.equal(result[4].toFixed(7), -1.5707964);
+  gpu.destroy();
+}
+
+test('Issue #647 atan2 - auto', () => {
+  buildAtan2KernelResult();
+});
+
+test('Issue #647 atan2 - gpu', () => {
+  buildAtan2KernelResult('gpu');
+});
+
+(GPU.isWebGLSupported ? test : skip)('Issue #647 atan2 - webgl', () => {
+  buildAtan2KernelResult('webgl');
+});
+
+(GPU.isWebGL2Supported ? test : skip)('Issue #647 atan2 - webgl2', () => {
+  buildAtan2KernelResult('webgl2');
+});
+
+(GPU.isHeadlessGLSupported ? test : skip)('Issue #647 atan2 - headlessgl', () => {
+  buildAtan2KernelResult('headlessgl');
+});
+
+test('Issue #647 atan2 - cpu', () => {
+  buildAtan2KernelResult('cpu');
+});


### PR DESCRIPTION
- Previous implementation returned values in -PI/2 to PI/2 range even though Javascript returns in -PI to PI range
- Add unit tests covering edge cases

Fixes #647 

Previously the following cases failed:

```
Math.atan2(1, 0);
Math.atan2(-1,0);
Math.atan(0,-1);
```

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2) `Math.atan2(y, x)` returns a value between -PI and PI. According to [OpenGL](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/atan.xhtml) `atan(y / x)` returns a value between -PI/2 and PI/2 while `atan(y, x)` returns a value between -PI and PI. 

The main fix was to change the `atan` signature to take `(y, x)` instead of `(y / x)` and then to handle the cases `Math.atan2(-1, 0)`, `Math.atan2(1, 0)`, `Math.atan(0, 0)` because in OpenGL `atan` is undefined when `x = 0` but defined in Javascript.

Note: `atan` arguments are passed `y` first and then `x`. This caused me some confusion at first.