### PR TITLE
Fix divWithIntCheck for floats larger than max int

### DIFF
--- a/src/backend/web-gl/kernel.js
+++ b/src/backend/web-gl/kernel.js
@@ -1086,7 +1086,7 @@ class WebGLKernel extends GLKernel {
   _getDivideWithIntegerCheckString() {
     return this.fixIntegerDivisionAccuracy ?
       `float divWithIntCheck(float x, float y) {
-  if (floor(x) == x && floor(y) == y && integerMod(x, y) == 0.0) {
+  if (int(x) == x && int(y) == y && integerMod(x, y) == 0.0) {
     return float(int(x) / int(y));
   }
   return x / y;


### PR DESCRIPTION
The integer accuracy fix could previously return a wrong result when its operands were bigger than max int.