### PR TITLE
Bug with complicated function dependencies

### DIFF
--- a/src/backend/function-builder.js
+++ b/src/backend/function-builder.js
@@ -292,9 +292,6 @@ class FunctionBuilder {
       if (functionIndex === -1) {
         retList.push(functionName);
         functionNode.toString(); //ensure JS trace is done
-        for (let i = 0; i < functionNode.calledFunctions.length; ++i) {
-          this.traceFunctionCalls(functionNode.calledFunctions[i], retList);
-        }
       } else {
         /**
          * https://github.com/gpujs/gpu.js/issues/207
@@ -303,6 +300,9 @@ class FunctionBuilder {
          * */
         const dependantFunctionName = retList.splice(functionIndex, 1)[0];
         retList.push(dependantFunctionName);
+      }
+      for (let i = 0; i < functionNode.calledFunctions.length; ++i) {
+        this.traceFunctionCalls(functionNode.calledFunctions[i], retList);
       }
     }
 

--- a/test/internal/complicated-function-dependencies.js
+++ b/test/internal/complicated-function-dependencies.js
@@ -1,0 +1,109 @@
+const { assert, skip, test, module: describe } = require("qunit");
+const { GPU } = require("../../src");
+
+describe("internal: complicated function dependencies");
+
+function a() {
+  b();
+  c();
+  d();
+  e();
+  f();
+  return 1;
+}
+function b() {
+  g();
+}
+function c() {
+  g();
+  return 1;
+}
+function d() {
+  g();
+  return 1;
+}
+function e() {
+  g();
+  return 1;
+}
+function f() {
+  i();
+  m();
+  return 1;
+}
+function g() {
+  i();
+  j();
+  k();
+  return 1;
+}
+function h() {
+  o();
+  return 1;
+}
+function i() {
+  return 1;
+}
+function j() {
+  m();
+  n();
+  return 1;
+}
+function k() {
+  return 1;
+}
+function l() {
+  o();
+  p();
+  return 1;
+}
+function m() {
+  return 1;
+}
+function n() {
+  return 1;
+}
+function o() {
+  return 1;
+}
+function p() {
+  b();
+  return 1;
+}
+
+function complicatedFunctionDependecies(mode) {
+  const gpu = new GPU({ mode });
+  gpu.setFunctions([a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p]);
+  const kernel = gpu
+    .createKernel(function () {
+      a();
+      return 1;
+    })
+    .setOutput([1]);
+
+  assert.deepEqual(kernel(), new Float32Array([1]));
+}
+
+test("auto", () => {
+  complicatedFunctionDependecies();
+});
+
+test("gpu", () => {
+  complicatedFunctionDependecies("gpu");
+});
+
+(GPU.isWebGLSupported ? test : skip)("webgl", () => {
+  complicatedFunctionDependecies("webgl");
+});
+
+(GPU.isWebGL2Supported ? test : skip)("webgl2", () => {
+  complicatedFunctionDependecies("webgl2");
+});
+
+(GPU.isHeadlessGLSupported ? test : skip)("headlessgl", () => {
+  complicatedFunctionDependecies("headlessgl");
+});
+
+test("cpu", () => {
+  complicatedFunctionDependecies("cpu");
+});


### PR DESCRIPTION
There was a bug when someone added a bunch of interdependent functions. I think it had to do with the order that they were declared in the shader. 
Here is a fix and a test for #727. 
