### PR TITLE
Bug fix: assign correct argument bit ratio index

### DIFF
--- a/src/backend/function-builder.js
+++ b/src/backend/function-builder.js
@@ -576,7 +576,7 @@ class FunctionBuilder {
       }
       return calleeBitRatio;
     }
-    calleeNode.argumentBitRatios[i] = bitRatio;
+    calleeNode.argumentBitRatios[argumentIndex] = bitRatio;
     return bitRatio;
   }
 


### PR DESCRIPTION
In "assignArgumentBitRatio" the index for "argumentBitRatios" should be the one of the function, not the kernel. Otherwise, you get a "bit ratio not found" error if you pass arguments to a function with a different order than they're passed to the kernel.
Fix #600