### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/backend/function-node.js
+++ b/src/backend/function-node.js
@@ -966,7 +966,7 @@ class FunctionNode {
     }
 
     const debugString = utils.getAstString(this.source, ast);
-    const leadingSource = this.source.substr(ast.start);
+    const leadingSource = this.source.slice(ast.start);
     const splitLines = leadingSource.split(/\n/);
     const lineBefore = splitLines.length > 0 ? splitLines[splitLines.length - 1] : 0;
     return new Error(`${error} on line ${ splitLines.length }, position ${ lineBefore.length }:\n ${ debugString }`);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.