### PR TITLE
Fix cropped rendering

### DIFF
--- a/src/backend/gl/kernel.js
+++ b/src/backend/gl/kernel.js
@@ -929,9 +929,9 @@ class GLKernel extends Kernel {
       this.updateMaxTexSize();
       this.framebuffer.width = this.texSize[0];
       this.framebuffer.height = this.texSize[1];
-      gl.viewport(0, 0, this.maxTexSize[0], this.maxTexSize[1]);
       this.canvas.width = this.maxTexSize[0];
       this.canvas.height = this.maxTexSize[1];
+      gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
       if (this.texture) {
         this.texture.delete();
       }

--- a/src/backend/web-gl/kernel.js
+++ b/src/backend/web-gl/kernel.js
@@ -491,15 +491,9 @@ class WebGLKernel extends GLKernel {
     }
     const { texSize, context: gl, canvas } = this;
     gl.enable(gl.SCISSOR_TEST);
-    if (this.pipeline && this.precision === 'single') {
-      gl.viewport(0, 0, this.maxTexSize[0], this.maxTexSize[1]);
-      canvas.width = this.maxTexSize[0];
-      canvas.height = this.maxTexSize[1];
-    } else {
-      gl.viewport(0, 0, this.maxTexSize[0], this.maxTexSize[1]);
-      canvas.width = this.maxTexSize[0];
-      canvas.height = this.maxTexSize[1];
-    }
+    canvas.width = this.maxTexSize[0];
+    canvas.height = this.maxTexSize[1];
+    gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
     const threadDim = this.threadDim = Array.from(this.output);
     while (threadDim.length < 3) {
       threadDim.push(1);


### PR DESCRIPTION
Resolves cropped rendering when WebGL drawing buffer is smaller than canvas due to hardware constraints by scaling viewport to drawing buffer rather than canvas size. See:
https://stackoverflow.com/questions/29710696/webgl-drawing-buffer-size-does-not-equal-canvas-size https://registry.khronos.org/webgl/specs/latest/1.0/#2.2