### PR TITLE
Fix return type of getPixels

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -175,7 +175,7 @@ export class Kernel {
   texture: Texture;
   mappedTextures?: Texture[];
   TextureConstructor: typeof Texture;
-  getPixels(flip?: boolean): Uint8ClampedArray[];
+  getPixels(flip?: boolean): Uint8ClampedArray;
   getVariablePrecisionString(textureSize?: number[], tactic?: Tactic, isInt?: boolean): string;
   prependString(value: string): void;
   hasPrependString(value: string): boolean;


### PR DESCRIPTION
There is an error in the definition of the return type of kernel.getPixels
Return type should be Uint8ClampedArray instead of Uint8ClampedArray[] (which would be an array of Uint8ClampedArray).