### PR TITLE
fix: Update GPU instantiation to use GPU.GPU() in example files

### DIFF
--- a/examples/fluid.html
+++ b/examples/fluid.html
@@ -27,7 +27,7 @@
       this.keys = {};
 
       this.canvas = document.createElement('canvas');
-      const gpu = this.gpu = new GPU({
+      const gpu = this.gpu = new GPU.GPU({
         canvas: this.canvas,
         mode: 'gpu'
       });

--- a/examples/internal-variable-precision.html
+++ b/examples/internal-variable-precision.html
@@ -10,7 +10,7 @@
 <script src="../dist/gpu-browser.min.js"></script>
 <script>
   const ivp = document.getElementById('ivp');
-  const gpu = new GPU();
+  const gpu = new GPU.GPU();
   const startSize = 10;
   const fullSize = window.innerWidth;
   const kernel = gpu.createKernel(function() {

--- a/examples/mandelbrot-set.html
+++ b/examples/mandelbrot-set.html
@@ -42,7 +42,7 @@
     return Math.sqrt(vector[0]*vector[0]+vector[1]*vector[1]);
   }
 
-  const gpu = new GPU();
+  const gpu = new GPU.GPU();
 
   gpu
     .addFunction(f)

--- a/examples/mandelbulb.html
+++ b/examples/mandelbulb.html
@@ -432,7 +432,7 @@
     document.addEventListener('pointerlockchange', lockChange, false);
 
     const gl = canvas.getContext('webgl2', { premultipliedAlpha: false });
-    const gpu = new GPU({ canvas, webGl: gl })
+    const gpu = new GPU.GPU({ canvas, webGl: gl })
       .addFunction(sdPlane)
       .addFunction(mandelbulb)
       .addFunction(distScene)

--- a/examples/parallel-raytracer.html
+++ b/examples/parallel-raytracer.html
@@ -1036,7 +1036,7 @@
         LIGHTSPHERE: Entity.Type.LIGHTSPHERE
       }
     };
-    var gpu = new GPU({ mode });
+    var gpu = new GPU.GPU({ mode });
     addFunctions(gpu, vectorFunctions);
     addFunctions(gpu, utilityFunctions);
     return gpu.createKernel(function(camera, lights, entities, eyeVector, vpRight, vpUp, canvasHeight, canvasWidth, fovRadians, heightWidthRatio, halfWidth, halfHeight, cameraWidth, cameraHeight, pixelWidth, pixelHeight, xOffset, yOffset) {

--- a/examples/random.html
+++ b/examples/random.html
@@ -16,18 +16,18 @@
 <script>
   let cpu, webGL, webGL2;
 
-  cpu = new GPU({
+  cpu = new GPU.GPU({
     mode: 'cpu',
     canvas: document.getElementById('cpu-random-output')
   });
   try {
-    webGL = new GPU({
+    webGL = new GPU.GPU({
       mode: 'webgl',
       canvas: document.getElementById('web-gl-random-output')
     });
   } catch (e) {}
   try {
-    webGL2 = new GPU({
+    webGL2 = new GPU.GPU({
       mode: 'webgl2',
       canvas: document.getElementById('web-gl2-random-output')
     });

--- a/examples/raytracer.html
+++ b/examples/raytracer.html
@@ -137,8 +137,8 @@
       tactic: 'precision',
     };
   };
-  const gpu = new GPU();
-  const cpu = new GPU({ mode: 'cpu'});
+  const gpu = new GPU.GPU();
+  const cpu = new GPU.GPU({ mode: 'cpu'});
   function vectorDotProduct(V1x, V1y, V1z, V2x, V2y, V2z) {
     return (V1x * V2x) + (V1y * V2y) + (V1z * V2z);
   }

--- a/examples/simple-javascript.js
+++ b/examples/simple-javascript.js
@@ -1,7 +1,5 @@
 const { GPU } = require('../src');
-
-const gpu = new GPU({ mode: 'gpu' });
-
+const gpu = new GPU();
 // Look ma! I can javascript on my GPU!
 function kernelFunction(anInt, anArray, aNestedArray) {
   const x = .25 + anInt + anArray[this.thread.x] + aNestedArray[this.thread.x][this.thread.y];

--- a/examples/slow-fade.html
+++ b/examples/slow-fade.html
@@ -13,7 +13,7 @@
 <script src="../dist/gpu-browser.min.js"></script>
 <script>
   const canvas = document.getElementById('c');
-  const gpu = new GPU({
+  const gpu = new GPU.GPU({
     canvas: canvas,
     mode: 'gpu'
   });


### PR DESCRIPTION
Fixes "Uncaught TypeError: GPU is not a constructor" error in HTML examples.